### PR TITLE
uncomment the py03 imports and the env vars no longer print

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,13 @@ criterion = { version = "0.4", default-features = false }
 serde_bytes = "0.11"
 lunatic = { path = ".", features = ["json_serializer", "msgpack_serializer"] }
 
+[build-dependencies]
+wlr-libpy = { git = "https://github.com/vmware-labs/webassembly-language-runtimes.git", features = ["build"] }
+
+[dependencies.pyo3]
+version = "0.19.1"
+features = ["auto-initialize","abi3-py311"]#,"extension-module"]#, "generate-import-lib"]#,
+
 [[bench]]
 name = "serializer"
 harness = false

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    use wlr_libpy::bld_cfg::configure_static_libs;
+    configure_static_libs().unwrap().emit_link_flags();
+}

--- a/examples/supervised_abstract_process/counter_abstract_process.rs
+++ b/examples/supervised_abstract_process/counter_abstract_process.rs
@@ -1,6 +1,11 @@
+use std::env;
 use lunatic::ap::Config;
 use lunatic::{abstract_process, Tag};
 
+// BUG???
+// UNCOMMENT OUT THESE LINES AND ENVIRONMENT VARIABLES WILL APPEAR!
+//use pyo3::Python;
+//use pyo3::types::IntoPyDict;
 pub struct Counter(u32);
 
 /// Abstract process using abstract_process macro.
@@ -24,6 +29,11 @@ impl Counter {
 
     #[handle_message]
     fn increment(&mut self) {
+        println!("Environment variables:");
+        for (key, value) in env::vars() {
+            println!("{key}: {value}");
+        };
+        println!("---------------------");
         self.0 += 1;
     }
 

--- a/examples/supervised_abstract_process/main.rs
+++ b/examples/supervised_abstract_process/main.rs
@@ -1,10 +1,12 @@
+use std::env;
+use std::time::Duration;
 mod counter_abstract_process;
 
 // Import the auto-generated `CounterHandler` public trait.
 use counter_abstract_process::{Counter, CounterMessages, CounterRequests};
 use lunatic::ap::{AbstractProcess, ProcessRef};
 use lunatic::supervisor::{Supervisor, SupervisorConfig, SupervisorStrategy};
-use lunatic::Mailbox;
+use lunatic::{Mailbox, ProcessConfig, sleep};
 
 // Supervisor definition.
 struct Sup;
@@ -20,6 +22,9 @@ impl Supervisor for Sup {
         config.set_args((0,));
         // Name child 'hello'
         config.set_names((Some("hello".to_owned()),));
+        let mut process_config = ProcessConfig::new().unwrap();
+            process_config.add_environment_variable("PYTHONPATH", "/foo/bar");
+            config.set_configs((Some(process_config),));
     }
 }
 
@@ -35,4 +40,7 @@ fn main(_: Mailbox<()>) {
     hello.increment();
 
     assert_eq!(hello.count(), 2);
+
+    // Give everything time to print.
+    sleep(Duration::from_millis(1));
 }


### PR DESCRIPTION
run with: 
```PY03_NO_PYTHON=1 cargo run --example supervised_abstract_process```